### PR TITLE
AsyncClient doesn't retry listOffsetRequest after server got ReplicaNotAvailableException

### DIFF
--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -45,6 +45,7 @@ import scala.jdk.CollectionConverters._
 class TransactionsTest extends IntegrationTestHarness {
   override def brokerCount = 3
 
+  val nonTransactionalProducerCount = 1
   val transactionalProducerCount = 2
   val transactionalConsumerCount = 1
   val nonTransactionalConsumerCount = 1
@@ -53,6 +54,7 @@ class TransactionsTest extends IntegrationTestHarness {
   val topic2 = "topic2"
   val numPartitions = 4
 
+  val nonTransactionalProducers = mutable.Buffer[KafkaProducer[Array[Byte], Array[Byte]]]()
   val transactionalProducers = mutable.Buffer[KafkaProducer[Array[Byte], Array[Byte]]]()
   val transactionalConsumers = mutable.Buffer[Consumer[Array[Byte], Array[Byte]]]()
   val nonTransactionalConsumers = mutable.Buffer[Consumer[Array[Byte], Array[Byte]]]()
@@ -94,6 +96,10 @@ class TransactionsTest extends IntegrationTestHarness {
     createTopic(topic1, numPartitions, brokerCount, topicConfig())
     createTopic(topic2, numPartitions, brokerCount, topicConfig())
 
+    for (_ <- 0 until nonTransactionalProducerCount) {
+      val producer = createProducer()
+      nonTransactionalProducers += producer
+    }
     for (_ <- 0 until transactionalProducerCount)
       createTransactionalProducer("transactional-producer")
     for (_ <- 0 until transactionalConsumerCount)
@@ -104,6 +110,7 @@ class TransactionsTest extends IntegrationTestHarness {
 
   @AfterEach
   override def tearDown(): Unit = {
+    nonTransactionalProducers.foreach(_.close())
     transactionalProducers.foreach(_.close())
     transactionalConsumers.foreach(_.close())
     nonTransactionalConsumers.foreach(_.close())
@@ -238,6 +245,34 @@ class TransactionsTest extends IntegrationTestHarness {
     assertNull(readCommittedOffsetsForTimes.get(tp1))
     assertNull(readCommittedOffsetsForTimes.get(tp2))
   }
+
+
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
+  @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))
+  def testReadCommittedConsumerShouldNotSeeUndecidedDataSimplify(quorum: String, groupProtocol: String): Unit = {
+    // ./gradlew :storage:test --tests TransactionsWithTieredStoreTest.testReadCommittedConsumerShouldNotSeeUndecidedDataSimplify  --rerun --fail-fast
+
+    val producer1 = nonTransactionalProducers.head
+    val readUncommittedConsumer = nonTransactionalConsumers.head
+
+    val latestVisibleTimestamp = System.currentTimeMillis()
+    val latestWrittenTimestamp = latestVisibleTimestamp + 1
+
+    producer1.send(new ProducerRecord(topic1, 0, latestWrittenTimestamp, "a".getBytes, "1".getBytes))
+    producer1.send(new ProducerRecord(topic1, 0, latestWrittenTimestamp, "b".getBytes, "2".getBytes))
+    producer1.flush()
+
+    val tp1 = new TopicPartition(topic1, 0)
+    readUncommittedConsumer.assign(Set(tp1).asJava)
+
+    // the offsetsForTimes is not retied because no metadata update triggered, so offsetsForTimes will be timeout
+    val readUncommittedOffsetsForTimes = readUncommittedConsumer.offsetsForTimes(Map(
+      tp1 -> (latestWrittenTimestamp: JLong)
+    ).asJava)
+    assertEquals(1, readUncommittedOffsetsForTimes.size)
+  }
+
+
 
   @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedQuorumAndGroupProtocolNames)
   @MethodSource(Array("getTestQuorumAndGroupProtocolParametersAll"))

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerTask.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerTask.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.log.remote.metadata.storage.serialization.RemoteLogMetadataSerde;
 import org.apache.kafka.server.log.remote.storage.RemoteLogMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
@@ -134,6 +135,9 @@ class ConsumerTask implements Runnable, Closeable {
         try {
             if (hasAssignmentChanged) {
                 maybeWaitForPartitionAssignments();
+                log.info("Make sure the readUncommittedConsumer.offsetsForTimes() happen before Remote log metadata cache initialization");
+                log.info("The call will trigger ReplicaNotAvailableException, consumer should retry it.");
+                Utils.sleep(2000);
             }
 
             log.trace("Polling consumer to receive remote log metadata topic records");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-18036  ( Tier Storage  + AsyncConsumer  )

不一致的情境:  
- 當 Server 發生  `ReplicaNotAvailableException: Remote log metadata cache is not initialized for partition: 5g5SryZAR4S_WyrDBFh7zQ:topic2-0)` 時, Client 會對此錯誤進行 Retry. https://github.com/apache/kafka/blob/86b552835c23590b4084a669594d78fc68b930a6/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcherUtils.java#L132-L142

**ClassicConsumer**: 會在同一個 Thread 重新發送 ListOffsetRequest  
**AsyncConsumer**: 只有在 metadata update 時才重新發送 ListOffsetRequest 

- Classic: https://github.com/apache/kafka/blob/86b552835c23590b4084a669594d78fc68b930a6/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetFetcher.java#L144-L146
- Async: https://github.com/apache/kafka/blob/64bbdb1a0319044d1fa60e3836ab4052c7a28c12/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsRequestManager.java#L528-L541