### PR TITLE
KAFKA-18298: Fix flaky PlaintextAdminIntegrationTest#testConsumerGroupsDeprecatedConsumerGroupState

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1864,17 +1864,20 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       val consumerSet = groupInstanceSet.map { groupInstanceId => createConsumer(configOverrides = createProperties(groupInstanceId))}
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
 
-      val latch = new CountDownLatch(consumerSet.size)
+      val startLatch = new CountDownLatch(consumerSet.size)
+      val stopLatch = new CountDownLatch(consumerSet.size)
+      val consumerThreadRunning = new AtomicBoolean(true)
+
       try {
         def createConsumerThread[K,V](consumer: Consumer[K,V], topic: String): Thread = {
           new Thread {
             override def run : Unit = {
               consumer.subscribe(Collections.singleton(topic))
               try {
-                while (true) {
+                while (consumerThreadRunning.get()) {
                   consumer.poll(JDuration.ofSeconds(5))
-                  if (!consumer.assignment.isEmpty && latch.getCount > 0L)
-                    latch.countDown()
+                  if (!consumer.assignment.isEmpty && startLatch.getCount > 0L)
+                    startLatch.countDown()
                   try {
                     consumer.commitSync()
                   } catch {
@@ -1883,6 +1886,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
                 }
               } catch {
                 case _: InterruptException => // Suppress the output to stderr
+              } finally {
+                stopLatch.countDown()
               }
             }
           }
@@ -1894,7 +1899,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
         try {
           consumerThreads.foreach(_.start())
-          assertTrue(latch.await(30000, TimeUnit.MILLISECONDS))
+          assertTrue(startLatch.await(30000, TimeUnit.MILLISECONDS))
           // Test that we can list the new group.
           TestUtils.waitUntilTrue(() => {
             val matching = client.listConsumerGroups.all.get.asScala.filter(group =>
@@ -2013,6 +2018,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           val firstMemberFuture = removeMembersResult.memberResult(new MemberToRemove(invalidInstanceId))
           assertFutureThrows(firstMemberFuture, classOf[UnknownMemberIdException])
 
+          // Stop the consumer threads before removing the group members to prevent rejoining.
+          consumerThreadRunning.set(false)
+          assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS))
+
           // Test consumer group deletion
           var deleteResult = client.deleteConsumerGroups(Seq(testGroupId, fakeGroupId).asJava)
           assertEquals(2, deleteResult.deletedGroups().size())
@@ -2036,6 +2045,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           val validMemberFuture = removeMembersResult.memberResult(new MemberToRemove(testInstanceId1))
           assertNull(validMemberFuture.get())
 
+          // The flaky was caused by rejoining of removed consumer member. Sleep for 1 second to simulate the scenario
+          // Reproduced: error: org.opentest4j.AssertionFailedError: expected: <2> but was: <3>
+          // Utils.sleep(1000)
+
           val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
             new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))
           assertEquals(1, describeTestGroupResult.describedGroups().size())
@@ -2049,6 +2062,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           // Delete all active members remaining (a static member + a dynamic member)
           removeMembersResult = client.removeMembersFromConsumerGroup(testGroupId, new RemoveMembersFromConsumerGroupOptions())
           assertNull(removeMembersResult.all().get())
+
+          // The flaky was caused by rejoining of removed consumer member. Sleep for 1 second to simulate the scenario
+          // Reproduced: error: org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
+          Utils.sleep(1000)
 
           // The group should contain no members now.
           testGroupDescription = client.describeConsumerGroups(Seq(testGroupId).asJava,

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -2230,17 +2230,20 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       val consumerSet = groupInstanceSet.map { groupInstanceId => createConsumer(configOverrides = createProperties(groupInstanceId))}
       val topicSet = Set(testTopicName, testTopicName1, testTopicName2)
 
-      val latch = new CountDownLatch(consumerSet.size)
+      val startLatch = new CountDownLatch(consumerSet.size)
+      val stopLatch = new CountDownLatch(consumerSet.size)
+      val consumerThreadRunning = new AtomicBoolean(true)
+
       try {
         def createConsumerThread[K,V](consumer: Consumer[K,V], topic: String): Thread = {
           new Thread {
             override def run : Unit = {
               consumer.subscribe(Collections.singleton(topic))
               try {
-                while (true) {
+                while (consumerThreadRunning.get()) {
                   consumer.poll(JDuration.ofSeconds(5))
-                  if (!consumer.assignment.isEmpty && latch.getCount > 0L)
-                    latch.countDown()
+                  if (!consumer.assignment.isEmpty && startLatch.getCount > 0L)
+                    startLatch.countDown()
                   try {
                     consumer.commitSync()
                   } catch {
@@ -2249,6 +2252,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
                 }
               } catch {
                 case _: InterruptException => // Suppress the output to stderr
+              } finally {
+                stopLatch.countDown()
               }
             }
           }
@@ -2260,7 +2265,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
         try {
           consumerThreads.foreach(_.start())
-          assertTrue(latch.await(30000, TimeUnit.MILLISECONDS))
+          assertTrue(startLatch.await(30000, TimeUnit.MILLISECONDS))
           // Test that we can list the new group.
           TestUtils.waitUntilTrue(() => {
             val matching = client.listConsumerGroups.all.get.asScala.filter(group =>
@@ -2413,6 +2418,10 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           assertFutureThrows(deleteResult.deletedGroups().get(testGroupId),
             classOf[GroupNotEmptyException])
 
+          // Stop the consumer threads before removing the group members to prevent rejoining.
+          consumerThreadRunning.set(false)
+          assertTrue(stopLatch.await(30000, TimeUnit.MILLISECONDS))
+
           // Test delete one correct static member
           val removeOptions = new RemoveMembersFromConsumerGroupOptions(Collections.singleton(new MemberToRemove(testInstanceId1)))
           removeOptions.reason("test remove")
@@ -2421,6 +2430,9 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
           assertNull(removeMembersResult.all().get())
           val validMemberFuture = removeMembersResult.memberResult(new MemberToRemove(testInstanceId1))
           assertNull(validMemberFuture.get())
+
+          // The flaky was caused by rejoining of removed members. Sleep for 1 second to simulate the scenario.
+          Utils.sleep(1000)
 
           val describeTestGroupResult = client.describeConsumerGroups(Seq(testGroupId).asJava,
             new DescribeConsumerGroupsOptions().includeAuthorizedOperations(true))


### PR DESCRIPTION
Stop consumers thread before removing group member to prevent member rejoining.

Fix below error:

- https://ge.apache.org/s/bkvjjpqfzeq6m/tests/task/:core:test/details/kafka.api.PlaintextAdminIntegrationTest/testConsumerGroupsDeprecatedConsumerGroupState(String%2C%20String)%5B2%5D?expanded-stacktrace=WyIwIl0&top-execution=1

```
org.opentest4j.AssertionFailedError: expected: <2> but was: <3>
 at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
 at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132) 
 at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197) 
 at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150) 
 at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145) 
 at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:531) 
at kafka.api.PlaintextAdminIntegrationTest.testConsumerGroupsDeprecatedConsumerGroupState(PlaintextAdminIntegrationTest.scala:2433) 
 at java.lang.reflect.Method.invoke(Method.java:580)
...
```